### PR TITLE
Improve paranoia in tcpdump output parsing.

### DIFF
--- a/arpspoofing-to-irc
+++ b/arpspoofing-to-irc
@@ -7,7 +7,7 @@ BEEHIVE_PORT="$4"
 
 SCRIPT_PATH="$(dirname `which $0`)"
 
-sudo tcpdump -l -i "$INTERFACE_NAME" -n 2>/dev/null \
+sudo tcpdump -l -i "$INTERFACE_NAME" -n arp 2>/dev/null \
     | "$SCRIPT_PATH/check_arp_replies" "$GATEWAY_IP" "$GATEWAY_MAC" | sed -une"/SPOOFED/p" \
     | while read line ; do
         wget -qO- "localhost:$BEEHIVE_PORT/?message=$line"

--- a/check_arp_replies
+++ b/check_arp_replies
@@ -7,6 +7,11 @@ import sys
 import subprocess as sub
 import re
 
+TCPDUMP_ARP_RE = re.compile(
+    # 22:57:19.552929 ARP, Reply 10.11.7.37 is-at 00:21:6a:0c:d2:e6, length 28
+    r'ARP, +Reply +(?P<ip>[0-9a-fA-F:.]+) +is-at +(?P<mac>[0-9a-fA-F:]+)'
+)
+
 
 def main(stdin):
     gateway_ip = sys.argv[1]
@@ -18,22 +23,18 @@ def main(stdin):
             print("OK\t({}): {}".format(*data), flush=True)
         else: #spoofed
             print("SPOOFED\t({}): {} -> {}".format(*data), flush=True)
-            
+
 def filter_input(stdin, gateway_ip, gateway_mac):
     for line in stdin:
-        if re.match(".*ARP.*Reply.*is-at.*", line):
-            # 22:57:19.552929 ARP, Reply 10.11.7.37 is-at 00:21:6a:0c:d2:e6, length 28
-            try:
-                _, _, _, ip, _, mac, _, _ = line.split(" ")
-            except ValueError as e:
-                print("Output mismatch: " + line, file=sys.stderr)
-            mac = mac[:-1] # strip comma
-            # print(ip, "\t", mac)
-            if ip == gateway_ip:
-                if mac == gateway_mac:
-                    yield ("ok", (ip, mac))
-                else:
-                    yield ("spoofed", (ip, gateway_mac, mac))
+        match = TCPDUMP_ARP_RE.search(line)
+        if match is None:
+            continue
+        ip, mac = match.group('ip', 'mac')
+        if ip == gateway_ip:
+            if mac == gateway_mac:
+                yield ("ok", (ip, mac))
+            else:
+                yield ("spoofed", (ip, gateway_mac, mac))
 
 def tests():
     import io

--- a/check_arp_replies
+++ b/check_arp_replies
@@ -7,10 +7,10 @@ import sys
 import subprocess as sub
 import re
 
-TCPDUMP_ARP_RE = re.compile(
+TCPDUMP_ARP_RE = re.compile((
     # 22:57:19.552929 ARP, Reply 10.11.7.37 is-at 00:21:6a:0c:d2:e6, length 28
-    r'ARP, +Reply +(?P<ip>[0-9a-fA-F:.]+) +is-at +(?P<mac>[0-9a-fA-F:]+)'
-)
+    r'ARP, +Reply +(?P<ip>XX(?:[:.]XX){3,7}) +is-at +(?P<mac>XX(?::XX){5}),'
+).replace('XX', '[0-9a-fA-F]{,4}'))
 
 
 def main(stdin):


### PR DESCRIPTION
The matches on the `tcpdump` output are way too lax and increase the attack vector for no particular reason. That I didn't find a practical exploit (yet) to attack it doesn't mean that we shouldn't check the inputs properly.

Even running `tcpdump` (and thus `libpcap`) looks still as quite a lot of overhead (and also an additional attack vector) to me, so if we only want to detect ARP spoofing that's concerning the gateway, checking the kernel ARP cache is enough. But if we want to detect spoofing on the whole network we can't get rid of packet capturing, so that might be a good idea for future work (also, what about [arpwatch-ng](http://freequaos.host.sk/arpwatch/)?).
